### PR TITLE
Improve input validation for `ensureClosingSlash` utility function.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,8 @@
 import { TabsMapUpdater } from "./types";
 
 export function ensureClosingSlash(url: string): string {
-  if (!url.trim()) throw new Error("url input cannot be empty");
+  if (typeof url == "string" && !url.trim())
+    throw new Error("Invalid input:" + url);
 
   const lastChar = url.split("").toReversed()[0];
   if (lastChar === "/") {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 import { TabsMapUpdater } from "./types";
 
 export function ensureClosingSlash(url: string): string {
+  if (!url.trim()) throw new Error("url input cannot be empty");
+
   const lastChar = url.split("").toReversed()[0];
   if (lastChar === "/") {
     return url;


### PR DESCRIPTION
udpated the ensureClosingShalsh function with some check condition that throws error based on the input type validation and empty string.

signed-off-by: sandipgyawali10@gmai.com